### PR TITLE
Updated README to have right namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library currently supports:
 Install this package with composer
 
 ```shell
-composer require tdanielcox/bluesnap-php
+composer require ventepos/bluesnap-php
 ```
 
 ### Usage
@@ -32,7 +32,7 @@ Initialize the library in your class constructor
 public function __construct()
 {
     $environment = 'sandbox'; // or 'production'
-    \tdanielcox\Bluesnap\Bluesnap::init($environment, 'YOUR_API_KEY', 'YOUR_API_PASSWORD');
+    \Bluesnap\Bluesnap::init($environment, 'YOUR_API_KEY', 'YOUR_API_PASSWORD');
 }
 ```
 
@@ -41,7 +41,7 @@ Create a New Transaction
 ```php
 public function createTransaction()
 {
-    $response = \tdanielcox\Bluesnap\CardTransaction::create([
+    $response = \Bluesnap\CardTransaction::create([
         'creditCard' => [
             'cardNumber' => '4263982640269299',
             'expirationMonth' => '02',
@@ -67,7 +67,7 @@ public function createTransaction()
 }
 ```
 
-#### See [examples](https://github.com/tdanielcox/bluesnap-php/tree/master/examples) for further details on using the library
+#### See [examples](https://github.com/ventepos/bluesnap-php/tree/master/examples) for further details on using the library
 
 ## License
-This package is licensed under the [MIT License](https://github.com/tdanielcox/bluesnap-php/blob/master/LICENSE)
+This package is licensed under the [MIT License](https://github.com/ventepos/bluesnap-php/blob/master/LICENSE)


### PR DESCRIPTION
ventepos/ not the old fork and namespace just \Bluesnap now