### PR TITLE
3050488 ach payment api

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ public function __construct()
 }
 ```
 
+Create a New Hosted Payment Fields Token
+
+```php
+public function getHostedPaymentFieldsToken() {
+  $data = \Bluesnap\HostedPaymentFieldsToken::create();
+  return $data['hosted_payment_fields_token'];
+}
+```
+
 Create a New Transaction
 
 ```php

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## Bluesnap PHP Library
+## BlueSnap PHP Library
 
-This (unofficial) library standardizes and simplifies working with the bluesnap api. 
+This (unofficial) library standardizes and simplifies working with the BlueSnap API. 
 
-All the standard api documentation is applicable to this library. 
+All the standard API documentation is applicable to this library. 
 
-View the bluesnap documentation here: https://developers.bluesnap.com/v8976-JSON/docs
+View the BlueSnap documentation here: https://developers.bluesnap.com/
 
 This library currently supports:
 
@@ -15,13 +15,14 @@ This library currently supports:
 - Plans (Subscriptions)
 - Refunds
 - Reports
+- Generating a Hosted Payment Fields token
 
 ### Installation
 
 Install this package with composer
 
 ```shell
-composer require tdanielcox/bluesnap-php
+composer require shabananavas/php-bluesnap-sdk
 ```
 
 ### Usage
@@ -32,7 +33,7 @@ Initialize the library in your class constructor
 public function __construct()
 {
     $environment = 'sandbox'; // or 'production'
-    \tdanielcox\Bluesnap\Bluesnap::init($environment, 'YOUR_API_KEY', 'YOUR_API_PASSWORD');
+    \Bluesnap\Bluesnap::init($environment, 'YOUR_API_KEY', 'YOUR_API_PASSWORD');
 }
 ```
 
@@ -41,7 +42,7 @@ Create a New Transaction
 ```php
 public function createTransaction()
 {
-    $response = \tdanielcox\Bluesnap\CardTransaction::create([
+    $response = \Bluesnap\CardTransaction::create([
         'creditCard' => [
             'cardNumber' => '4263982640269299',
             'expirationMonth' => '02',
@@ -67,7 +68,7 @@ public function createTransaction()
 }
 ```
 
-#### See [examples](https://github.com/tdanielcox/bluesnap-php/tree/master/examples) for further details on using the library
+#### See [examples](https://github.com/shabananavas/php-bluesnap-sdk/tree/master/examples) for further details on using the library
 
 ## License
-This package is licensed under the [MIT License](https://github.com/tdanielcox/bluesnap-php/blob/master/LICENSE)
+This package is licensed under the [MIT License](https://github.com/shabananavas/php-bluesnap-sdk/blob/master/LICENSE)

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "ventepos/bluesnap-php",
-    "description": "A PHP Library for the Bluesnap api",
+    "name": "shabananavas/php-bluesnap-sdk",
+    "description": "A PHP SDK for the BlueSnap API",
     "keywords": ["bluesnap", "laravel"],
     "type": "library",
     "license": "MIT",
-    "homepage": "https://github.com/ventepos/bluesnap-php",
+    "homepage": "https://github.com/shabananavas/php-bluesnap-sdk",
     "authors": [
+        {
+            "name": "Shabana Navas",
+            "email": "snavas@acromedia.com"
+        },
         {
             "name": "Patrick McCarren",
             "email": "patrick@mmsc.io"

--- a/src/Bluesnap/Adapter.php
+++ b/src/Bluesnap/Adapter.php
@@ -59,7 +59,6 @@ class Adapter
         {
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model);
-
             $response = Api::post($endpoint, $data, $id_in_header);
 
             if ($id_in_header)
@@ -98,7 +97,6 @@ class Adapter
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model, $id);
             $endpoint = $id_in_url ? $endpoint .'/'. $id : $endpoint;
-
             $response = Api::put($endpoint, $data);
             $model = Utility::setupModel($model, $response);
 

--- a/src/Bluesnap/AltTransaction.php
+++ b/src/Bluesnap/AltTransaction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bluesnap;
+
+/**
+ * Class CardTransaction
+ */
+class AltTransaction
+{
+    public static function get($id = null)
+    {
+        return Adapter::get('AltTransaction', $id);
+    }
+
+    public static function create($data)
+    {
+        return Adapter::create('AltTransaction', $data, [
+            'id_in_header' => false
+        ]);
+    }
+
+    public static function update($id, $data)
+    {
+        return Adapter::update('AltTransaction', $id, $data, [
+            'id_in_url' => false
+        ]);
+    }
+}

--- a/src/Bluesnap/Api.php
+++ b/src/Bluesnap/Api.php
@@ -22,8 +22,9 @@ class Api
             'base_uri' => $base_url,
 //            'timeout'  => 10.0,
             'auth' => $credentials,
+            'bluesnap-version' => '3.0',
             'headers' => [
-                'Accept' => 'application/json'
+                'Accept' => 'application/json',
             ]
         ]);
     }
@@ -53,7 +54,6 @@ class Api
     public static function post($endpoint, $data, $id_in_header)
     {
         $client = self::getClient();
-
     //    $clientHandler = $client->getConfig('handler');
     //    $tapMiddleware = Middleware::tap(function ($request) {
     //        echo "Request data:\n\ncontent-type: ". $request->getHeaderLine('Content-Type') ."\n";

--- a/src/Bluesnap/Api.php
+++ b/src/Bluesnap/Api.php
@@ -70,8 +70,13 @@ class Api
             if ($id_in_header && $response->hasHeader('Location')) {
                 $location = $response->getHeader('Location');
                 $location_array = explode('/', $location[0]);
-                $model_id = end($location_array);
 
+                // If we're fetching a Hosted Payment Fields token, return that.
+                if ($endpoint == 'payment-fields-tokens') {
+                  return ['hosted_payment_fields_token' => $location_array[6]];
+                }
+
+                $model_id = end($location_array);
                 return [ 'id' => (int) $model_id ];
             } else {
                 $model = $response->getBody()->getContents();

--- a/src/Bluesnap/HostedPaymentFieldsToken.php
+++ b/src/Bluesnap/HostedPaymentFieldsToken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bluesnap;
+
+/**
+ * Class HostedPaymentFieldsToken.
+ */
+class HostedPaymentFieldsToken {
+
+  /**
+   * Create a BlueSnap Hosted Payment Fields token.
+   *
+   * @return array|mixed|\Psr\Http\Message\ResponseInterface
+   */
+  public static function create() {
+    return Api::post('payment-fields-tokens', NULL, TRUE);
+  }
+
+}

--- a/src/Bluesnap/HostedPaymentFieldsToken.php
+++ b/src/Bluesnap/HostedPaymentFieldsToken.php
@@ -10,7 +10,8 @@ class HostedPaymentFieldsToken {
   /**
    * Create a BlueSnap Hosted Payment Fields token.
    *
-   * @return array|mixed|\Psr\Http\Message\ResponseInterface
+   * @return array
+   *   An array with the token in 'hosted_payment_fields_token'.
    */
   public static function create() {
     return Api::post('payment-fields-tokens', NULL, TRUE);

--- a/src/Bluesnap/Models/AltTransaction.php
+++ b/src/Bluesnap/Models/AltTransaction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Bluesnap\Models;
+
+/**
+ * Class AltTransaction
+ */
+class AltTransaction extends Model
+{
+    public function __construct($data = null)
+    {
+        parent::__construct($data, 'transactionId');
+    }
+
+    protected $children = ['transactionMetaData' => self::ITEM, 'vendorInfo' => self::ITEM];
+
+
+    /**
+     * Amount to be charged in the transaction, including decimal points.
+     * @var string
+     */
+    public $amount;
+
+    /**
+     * Enter ECOMMERCE for a one-time transaction or RECURRING for a recurring transaction.
+     * @var string
+     */
+    public $recurringTransaction;
+
+    /**
+     * Merchant's unique ID for a new transaction. Length: 1..50
+     * @var string
+     */
+    public $merchantTransactionId;
+
+    /**
+     * Description of the transaction, which appears on the shopper's credit card statement.
+     * @var string $softDescriptor
+     */
+    public $softDescriptor;
+
+    /**
+     * ID of an existing vaulted shopper.
+     * @var string
+     */
+    public $vaultedShopperId;
+
+    /**
+     * Currency code (ISO 4217) of the amount to be charged.
+     * @var string
+     */
+    public $currency;
+
+    /**
+     * @var TransactionMetaData
+     */
+    public $transactionMetaData;
+
+    /**
+     * @var TransactionFraudInfo
+     */
+    public $transactionFraudInfo;
+}

--- a/src/Bluesnap/Utility.php
+++ b/src/Bluesnap/Utility.php
@@ -56,6 +56,7 @@ class Utility
             'SubscriptionCharge' => 'recurring/subscriptions/charges',
             'VaultedShopper' => 'vaulted-shoppers',
             'Vendor' => 'vendors',
+            'AltTransaction' => 'alt-transactions',
         ];
 
         return $models[$model];
@@ -76,7 +77,6 @@ class Utility
 
             return $models;
         }
-
         return new $class_path($data);
     }
 }


### PR DESCRIPTION
* Add support for ACH Payments
* Multiple ACH payments for vaulted shopper is only supported in version 3, hence I have modified the API version to use to be `3.0`. ACH functionality was working correctly, Will need to check for Hosted payment fields